### PR TITLE
Fix wait_for_device user step during OAuth Flow

### DIFF
--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -74,8 +74,6 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Error while initiating Tado")
                 return self.async_abort(reason="cannot_connect")
             assert self.tado is not None
-            tado_device_url = self.tado.device_verification_url()
-            user_code = URL(tado_device_url).query["user_code"]
 
         async def _wait_for_login() -> None:
             """Wait for the user to login."""
@@ -107,6 +105,10 @@ class TadoConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             return self.async_show_progress_done(next_step_id="finish_login")
 
+        tado_device_url = self.tado.device_verification_url()
+        user_code = URL(tado_device_url).query["user_code"]
+        _LOGGER.debug("tado_device_url: %s Code: %s", tado_device_url, user_code)
+        
         return self.async_show_progress(
             step_id="user",
             progress_action="wait_for_device",


### PR DESCRIPTION
There is an issue with the code, where `tado_device_url` and `user_code` are not defined, if `self.tado is not None`. 

Also, `tado_device_url` is not available, when we are in the `self.login_task.done` state, so we have to use them after the check.